### PR TITLE
Modify Mac Defaults and Change Query Order

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.x
+- 1.11.x
 os:
 - linux
 - osx

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ The following table shows what is used if the envrionment variable is not set. I
 |  | Linux | Mac | Windows |
 | ---: | :---: | :---: | :---: |
 | `XDG_DATA_DIRS` | [`/usr/local/share`, `/usr/share`] | [`/Library/Application Support`] | `%PROGRAMDATA%` |
-| `XDG_DATA_HOME` | `~/.local/share` | `~/.local/share` | `%APPDATA%` |
+| `XDG_DATA_HOME` | `~/.local/share` | `~/Library/Application Support` | `%APPDATA%` |
 | `XDG_CONFIG_DIRS` | [`/etc/xdg`] | [`/Library/Application Support`] | `%PROGRAMDATA%` |
-| `XDG_CONFIG_HOME` | `~/.config` | `~/.config` | `%APPDATA%` |
+| `XDG_CONFIG_HOME` | `~/.config` | `~/Library/Application Support` | `%APPDATA%` |
 | `XDG_CACHE_HOME` | `~/.cache` | `~/Library/Cache` | `%LOCALAPPDATA%` |
 
 ## Notes

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The following table shows what is used if the envrionment variable is not set. I
 | `XDG_DATA_HOME` | `~/.local/share` | `~/.local/share` | `%APPDATA%` |
 | `XDG_CONFIG_DIRS` | [`/etc/xdg`] | [`/Library/Application Support`] | `%PROGRAMDATA%` |
 | `XDG_CONFIG_HOME` | `~/.config` | `~/.config` | `%APPDATA%` |
-| `XDG_CACHE_HOME` | `~/.cache` | `~/.cache` | `%LOCALAPPDATA%` |
+| `XDG_CACHE_HOME` | `~/.cache` | `~/Library/Cache` | `%LOCALAPPDATA%` |
 
 ## Notes
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,17 +1,16 @@
 version: 0.0.1_{build}
+build: off
 platform: x64
 clone_folder: c:\gopath\src\github.com\OpenPeeDeeP\xdg
 environment:
   GOPATH: c:\gopath
+stack: go 1.10
 install:
-- echo %PATH%
-- echo %GOPATH%
-- set PATH=%GOPATH%\bin;c:\go\bin;%PATH%
-- go version
-- go env
-- go get -t -v ./...
-- cinst codecov
-build_script:
-- go test -v -race -covermode=atomic -coverprofile=coverage.txt
+  - go get -t -v ./...
+  - cinst codecov
+before_test:
+  - go vet ./...
+test_script:
+  - go test -v -race -covermode=atomic -coverprofile=coverage.txt
 on_success:
-- codecov -f coverage.txt
+  - codecov -f coverage.txt

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ platform: x64
 clone_folder: c:\gopath\src\github.com\OpenPeeDeeP\xdg
 environment:
   GOPATH: c:\gopath
-stack: go 1.10
+stack: go 1.11
 install:
   - go get -t -v ./...
   - cinst codecov

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/OpenPeeDeeP/xdg
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.1.1 // indirect
+	github.com/stretchr/testify v1.2.2
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
+github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/xdg.go
+++ b/xdg.go
@@ -81,7 +81,7 @@ func (x *XDG) CacheHome() string {
 // Returns an empty string if one was not found.
 func (x *XDG) QueryData(filename string) string {
 	dirs := x.DataDirs()
-	dirs = append(dirs, x.DataHome())
+	dirs = append([]string{x.DataHome()}, dirs...)
 	return returnExist(filename, dirs)
 }
 
@@ -89,7 +89,7 @@ func (x *XDG) QueryData(filename string) string {
 // Returns an empty string if one was not found.
 func (x *XDG) QueryConfig(filename string) string {
 	dirs := x.ConfigDirs()
-	dirs = append(dirs, x.ConfigHome())
+	dirs = append([]string{x.ConfigHome()}, dirs...)
 	return returnExist(filename, dirs)
 }
 

--- a/xdg_darwin.go
+++ b/xdg_darwin.go
@@ -26,5 +26,5 @@ func (o *osDefaulter) defaultConfigDirs() []string {
 }
 
 func (o *osDefaulter) defaultCacheHome() string {
-	return filepath.Join(os.Getenv("HOME"), ".cache")
+	return filepath.Join(os.Getenv("HOME"), "Library", "Caches")
 }

--- a/xdg_darwin.go
+++ b/xdg_darwin.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (o *osDefaulter) defaultDataHome() string {
-	return filepath.Join(os.Getenv("HOME"), ".local", "share")
+	return filepath.Join(os.Getenv("HOME"), "Library", "Application Support")
 }
 
 func (o *osDefaulter) defaultDataDirs() []string {
@@ -18,7 +18,7 @@ func (o *osDefaulter) defaultDataDirs() []string {
 }
 
 func (o *osDefaulter) defaultConfigHome() string {
-	return filepath.Join(os.Getenv("HOME"), ".config")
+	return filepath.Join(os.Getenv("HOME"), "Library", "Application Support")
 }
 
 func (o *osDefaulter) defaultConfigDirs() []string {

--- a/xdg_darwin_test.go
+++ b/xdg_darwin_test.go
@@ -17,7 +17,7 @@ func TestDefaultDataHome(t *testing.T) {
 	setDefaulter(new(osDefaulter))
 	assert := assert.New(t)
 	homeDir := "/some/path"
-	expected := homeDir + "/.local/share"
+	expected := homeDir + "/Library/Application Support"
 	os.Setenv("HOME", homeDir) // nolint: errcheck
 
 	actual := defaulter.defaultDataHome()
@@ -37,7 +37,7 @@ func TestDefaultConfigHome(t *testing.T) {
 	setDefaulter(new(osDefaulter))
 	assert := assert.New(t)
 	homeDir := "/some/path"
-	expected := homeDir + "/.config"
+	expected := homeDir + "/Library/Application Support"
 	os.Setenv("HOME", homeDir) // nolint: errcheck
 
 	actual := defaulter.defaultConfigHome()

--- a/xdg_darwin_test.go
+++ b/xdg_darwin_test.go
@@ -57,7 +57,7 @@ func TestDefaultCacheHome(t *testing.T) {
 	setDefaulter(new(osDefaulter))
 	assert := assert.New(t)
 	homeDir := "/some/path"
-	expected := homeDir + "/.cache"
+	expected := homeDir + "/Library/Caches"
 	os.Setenv("HOME", homeDir) // nolint: errcheck
 
 	actual := defaulter.defaultCacheHome()


### PR DESCRIPTION
I am also adding support for go modules so that users can use `v0.1.0` before these changes and still get the same functionality as some of these changes are breaking. But since I never made a `v1` release I think this is fine.

Fixes #1 
Fixes #2 